### PR TITLE
Adapted embassy tick frequency and make ch32v003 example build

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ For a full list of chip capabilities and peripherals, check the [ch32-data](http
 
 ### Notes
 - For USB OTGFS and HS, look at the `mod.rs` respsectively to understand what is / is not tested.
+- Default clock frequency of examples is 8Mhz with an embassy tick frequency of 10Khz. This is changed
+  because default embassy tick of embassy_time is 1Mhz which is too fast.
+  Chose an embassy tick frequency fiting to your project.
 
 ### TODOs
 

--- a/examples/ch32l103/Cargo.toml
+++ b/examples/ch32l103/Cargo.toml
@@ -15,7 +15,7 @@ embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = { version = "0.4.0" }
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke = "*"

--- a/examples/ch32v003/Cargo.toml
+++ b/examples/ch32v003/Cargo.toml
@@ -16,7 +16,7 @@ embassy-executor = { version = "0.7.0", features = [
     "executor-thread",
     "task-arena-size-128", # or better use nightly, but fails on recent Rust versions
 ] }
-embassy-time = { version = "0.4.0" }
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke = "*"

--- a/examples/ch32v003/Cargo.toml
+++ b/examples/ch32v003/Cargo.toml
@@ -35,3 +35,5 @@ micromath = { version = "2.1.0", features = ["num-traits"] }
 strip = false   # symbols are not flashed to the microcontroller, so don't strip them.
 lto = true
 opt-level = "s" # Optimize for size.
+codegen-units = 1
+debug = true

--- a/examples/ch32v103/Cargo.toml
+++ b/examples/ch32v103/Cargo.toml
@@ -14,7 +14,7 @@ embassy-executor = { version = "0.7.0", features = [
     "arch-spin",
     "executor-thread",
 ] }
-embassy-time = { version = "0.4.0" }
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke-rt = "*"

--- a/examples/ch32v203/Cargo.toml
+++ b/examples/ch32v203/Cargo.toml
@@ -17,7 +17,7 @@ embassy-executor = { version = "0.7.0", features = [
     "executor-thread",
 ] }
 
-embassy-time = { version = "0.4.0" }
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 embassy-usb = { version = "0.3.0" }
 embassy-futures = { version = "0.1.0" }
 

--- a/examples/ch32v208/Cargo.toml
+++ b/examples/ch32v208/Cargo.toml
@@ -14,7 +14,7 @@ embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = { version = "0.4.0" }
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke-rt = "*"

--- a/examples/ch32v305/Cargo.toml
+++ b/examples/ch32v305/Cargo.toml
@@ -14,7 +14,7 @@ embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = { version = "0.4.0" }
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 
 qingke-rt = "*"
 qingke = "*"

--- a/examples/ch32v307/Cargo.toml
+++ b/examples/ch32v307/Cargo.toml
@@ -19,7 +19,7 @@ embassy-executor = { version = "0.7.0", features = [
 
 critical-section = "1.2.0"
 
-embassy-time = "0.4.0"
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 embassy-usb = "0.3.0"
 nb = "1.1.0"
 

--- a/examples/ch32x035/Cargo.toml
+++ b/examples/ch32x035/Cargo.toml
@@ -14,7 +14,7 @@ embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = { version = "0.4.0" }
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 
 qingke-rt = "*"
 qingke = "*"

--- a/examples/ch641/Cargo.toml
+++ b/examples/ch641/Cargo.toml
@@ -16,7 +16,7 @@ embassy-executor = { version = "0.7.0", features = [
     "executor-thread",
     "task-arena-size-128", # or better use nightly, but fails on recent Rust versions
 ] }
-embassy-time = { version = "0.4.0" }
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 embedded-hal = "1.0.0"
 
 qingke-rt = "*"


### PR DESCRIPTION
Set embassy tick frequency for all examples to 10kHz which seems to work with a default clock frequency of 8Mhz and systick. Added build parameter for ch32v003 example to make all examples build. This is a problem already mentioned in #https://github.com/embassy-rs/embassy/issues/4290.